### PR TITLE
fr/fix package builder

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "typecheck": "tsc --noEmit",
     "electron:dev": "electron .",
     "electron:build": "npm run build && electron-builder",
-    "package": "electron-packager . CosmicDesktop --overwrite --asar=true --platform=darwin --arch=x64 --icon=assets/icon.icns --prune=true --out=release-builds"
+    "package": "electron-packager . CosmicDesktop --overwrite --asar --platform=darwin --arch=x64 --icon=assets/icon.icns --prune=true --out=release-builds"
   },
   "dependencies": {
     "@genkit-ai/googleai": "^1.0.4",


### PR DESCRIPTION
This pull request makes a small adjustment to the `package.json` file by simplifying the `package` script for the Electron app.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L15-R15): Removed the explicit `=true` value for the `--asar` flag in the `package` script, as it is implicitly true when the flag is present.